### PR TITLE
fix: update profile page to refetch after a contribution is made

### DIFF
--- a/src/screens/users/ProfileScreen/CommunityDonationsImpactCards/index.tsx
+++ b/src/screens/users/ProfileScreen/CommunityDonationsImpactCards/index.tsx
@@ -7,15 +7,22 @@ import { formatDateTime } from "lib/formatters/dateFormatter";
 import CardImageText from "components/moleculars/CardImageText";
 import { theme } from "@ribon.io/shared/styles";
 import { formatPrice } from "lib/formatters/currencyFormatter";
+import { logEvent } from "services/analytics";
+import { useFocusEffect } from "@react-navigation/native";
 import ImpactDonationsVector from "./ImpactDonationsVector";
 import S from "./styles";
 import ZeroDonationsSection from "../ZeroDonationsSection";
-import { logEvent } from "services/analytics";
 
 function CommunityDonationsImpactCards(): JSX.Element {
   const { useCommunityPersonPayments } = usePersonPayments();
 
-  const { data } = useCommunityPersonPayments(1, 6);
+  const { data, refetch } = useCommunityPersonPayments(1, 6);
+
+  useFocusEffect(
+    useCallback(() => {
+      refetch();
+    }, []),
+  );
 
   const impactItems = useCallback(() => data || [], [data]);
   const hasImpact = impactItems() && impactItems()?.length > 0;
@@ -25,7 +32,7 @@ function CommunityDonationsImpactCards(): JSX.Element {
   });
 
   const navigateToPromotersScreen = () => {
-    logEvent("giveCauseCard_click", { from: "impactEmptystate"});
+    logEvent("giveCauseCard_click", { from: "impactEmptystate" });
     navigateTo("PromotersScreen");
   };
 

--- a/src/screens/users/ProfileScreen/DirectDonationsImpactCards/index.tsx
+++ b/src/screens/users/ProfileScreen/DirectDonationsImpactCards/index.tsx
@@ -5,15 +5,22 @@ import { useTranslation } from "react-i18next";
 import usePersonPayments from "hooks/apiHooks/usePersonPayments";
 import { theme } from "@ribon.io/shared/styles";
 import DirectDonationCard from "screens/users/ProfileScreen/DirectDonationsImpactCards/DirectDonationCard";
+import { logEvent } from "services/analytics";
+import { useFocusEffect } from "@react-navigation/native";
 import ImpactDonationsVector from "./ImpactDonationsVector";
 import S from "./styles";
 import ZeroDonationsSection from "../ZeroDonationsSection";
-import { logEvent } from "services/analytics";
 
 function DirectDonationsImpactCards(): JSX.Element {
   const { useDirectPersonPayments } = usePersonPayments();
 
-  const { data } = useDirectPersonPayments(1, 6);
+  const { data, refetch } = useDirectPersonPayments(1, 6);
+
+  useFocusEffect(
+    useCallback(() => {
+      refetch();
+    }, []),
+  );
 
   const impactItems = useCallback(() => data || [], [data]);
   const hasImpact = impactItems() && impactItems()?.length > 0;
@@ -23,7 +30,7 @@ function DirectDonationsImpactCards(): JSX.Element {
   });
 
   const navigateToPromotersScreen = () => {
-    logEvent("giveNonProfitCard_click", { from: "impactEmptystate"});
+    logEvent("giveNonProfitCard_click", { from: "impactEmptystate" });
     navigateTo("PromotersScreen", { isInCommunity: false });
   };
 

--- a/src/screens/users/ProfileScreen/index.tsx
+++ b/src/screens/users/ProfileScreen/index.tsx
@@ -1,12 +1,11 @@
 import React, { useCallback, useEffect } from "react";
-import { useTranslation } from "react-i18next";
-import { Text, ScrollView, View } from "react-native";
+import { View } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import { useCurrentUser } from "contexts/currentUserContext";
 import { useImpact, useStatistics } from "@ribon.io/shared/hooks";
+import { logEvent } from "services/analytics";
 import TabViewSection from "./TabViewSection";
 import S from "./styles";
-import { logEvent } from "services/analytics";
 
 function ProfileScreen() {
   const { currentUser } = useCurrentUser();


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Add refetch when the user goes to the profile page for the Community and Direct contributions sections
The user was not able to see his contribution after it was done. It had to close the app and open it again so he sees his new contribution

# Necessary changes

- Put here any changes that must be done when this PR is merged
- eg: update an environment variable

## Does this pull request close any open issues?

- Put here the issue that must be closed with this PR
- eg: closes [#001]()

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
