### PR TITLE
fix: update padding bottom in impact tabs

### DIFF
--- a/src/components/moleculars/ParallaxTabViewContainer/index.tsx
+++ b/src/components/moleculars/ParallaxTabViewContainer/index.tsx
@@ -2,12 +2,13 @@ import * as React from "react";
 import { useCollapsibleScene } from "react-native-collapsible-tab-view";
 import { Animated } from "react-native";
 
-const ParallaxTabViewContainer: React.FC<{
+type Props = {
   routeKey: string;
-  children: JSX.Element;
-}> = ({ routeKey, children }) => {
+  children: JSX.Element | JSX.Element[];
+};
+function ParallaxTabViewContainer({ routeKey, children }: Props) {
   const scrollPropsAndRef = useCollapsibleScene(routeKey);
-  const {contentContainerStyle } = scrollPropsAndRef;
+  const { contentContainerStyle } = scrollPropsAndRef;
 
   return (
     <Animated.ScrollView
@@ -15,12 +16,13 @@ const ParallaxTabViewContainer: React.FC<{
       showsVerticalScrollIndicator={false}
       contentContainerStyle={{
         ...contentContainerStyle,
-        minHeight: 670
+        minHeight: 670,
+        paddingBottom: 200,
       }}
     >
       {children}
     </Animated.ScrollView>
   );
-};
+}
 
 export default ParallaxTabViewContainer;

--- a/src/screens/users/ProfileScreen/ZeroDonationsSection/styles.ts
+++ b/src/screens/users/ProfileScreen/ZeroDonationsSection/styles.ts
@@ -15,6 +15,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     marginTop: theme.spacingNative(20),
     paddingHorizontal: theme.spacingNative(20),
+    paddingBottom: theme.spacingNative(20),
   },
   zeroDonationsTitle: {
     ...defaultBodyMdBold,


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Fix impact screen bottom paddings on the tab view

The last cards were being cutted from the screen

# Necessary changes

- Put here any changes that must be done when this PR is merged
- eg: update an environment variable

## Does this pull request close any open issues?

- Put here the issue that must be closed with this PR
- eg: closes [#001]()

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
