### PR TITLE
fix: sets donate navigation to causes page

### DIFF
--- a/src/screens/content/ForYouScreen/LockedSection/index.tsx
+++ b/src/screens/content/ForYouScreen/LockedSection/index.tsx
@@ -12,7 +12,7 @@ export default function LockedSection() {
   const { navigateTo } = useNavigation();
 
   const handleButtonClick = () => {
-    navigateTo("PixInstructionsScreen");
+    navigateTo("CausesScreen");
   };
 
   return (


### PR DESCRIPTION
sets navigation when user has not donated to causes page instead of pix page