### PR TITLE
[PROD3-501] Refresing when scroll down on causes page 

### DIFF
--- a/src/screens/donations/CausesScreen/ClubSection/index.tsx
+++ b/src/screens/donations/CausesScreen/ClubSection/index.tsx
@@ -3,15 +3,21 @@ import { TouchableOpacity, Image } from "react-native";
 import { useLanguage } from "contexts/languageContext";
 import { useCallback, useEffect, useState } from "react";
 import { useCurrentUser } from "contexts/currentUserContext";
-import { useSubscriptions } from "@ribon.io/shared/hooks";
 import { useFocusEffect } from "@react-navigation/native";
 import { logEvent } from "services/analytics";
 import S from "./styles";
 
-export default function ClubSection(): JSX.Element | null {
+type Props = {
+  isMember: boolean;
+  refetch: () => void;
+};
+
+export default function ClubSection({
+  isMember,
+  refetch,
+}: Props): JSX.Element | null {
   const { currentLang } = useLanguage();
-  const { userIsMember } = useSubscriptions();
-  const { isMember, refetch } = userIsMember();
+
   const { navigateTo } = useNavigation();
   const { currentUser } = useCurrentUser();
   const [isLoading, setIsLoading] = useState(false);

--- a/src/screens/donations/CausesScreen/index.tsx
+++ b/src/screens/donations/CausesScreen/index.tsx
@@ -323,7 +323,7 @@ export default function CausesScreen() {
     } finally {
       setRefreshing(false);
     }
-  }, [isMember]);
+  }, [refetchTickets, refetchIsMember, refetchFirstAccessToIntegration]);
 
   return isLoading || loadingFirstAccessToIntegration ? (
     <Placeholder />

--- a/src/screens/donations/CausesScreen/index.tsx
+++ b/src/screens/donations/CausesScreen/index.tsx
@@ -3,8 +3,9 @@ import {
   useStories,
   useFirstAccessToIntegration,
   useDonatedToday,
+  useSubscriptions,
 } from "@ribon.io/shared/hooks";
-import { ScrollView, Text, View } from "react-native";
+import { ScrollView, Text, View, RefreshControl } from "react-native";
 import { useNavigation } from "hooks/useNavigation";
 import { useTranslation } from "react-i18next";
 import CardCenterImageButton from "components/moleculars/CardCenterImageButton";
@@ -68,6 +69,7 @@ export default function CausesScreen() {
   } = useFirstAccessToIntegration(currentIntegrationId);
   const { integration } = useIntegrationContext();
   const { ticketsCounter } = useTicketsContext();
+
   const [storiesVisible, setStoriesVisible] = useState(false);
   const [stories, setStories] = useState<Story[]>([]);
   const [currentNonProfit, setCurrentNonProfit] = useState<NonProfit>(
@@ -75,6 +77,8 @@ export default function CausesScreen() {
   );
   const [isNotificationCardVisible, setNotificationCardVisible] =
     useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+
   const { navigateTo } = useNavigation();
   const scrollViewRef = useRef<any>(null);
   const { fetchNonProfitStories } = useStories();
@@ -305,11 +309,33 @@ export default function CausesScreen() {
     }
   };
 
+  const { userIsMember } = useSubscriptions();
+  const { isMember, refetch: refetchIsMember } = userIsMember();
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      refetchTickets();
+      await refetchIsMember();
+      await refetchFirstAccessToIntegration();
+    } catch (e) {
+      logError(e);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [isMember]);
+
   return isLoading || loadingFirstAccessToIntegration ? (
     <Placeholder />
   ) : (
     <>
-      <ScrollView style={S.container} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        style={S.container}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        }
+      >
         <View style={S.containerPadding}>
           {currentNonProfit && (
             <StoriesSection
@@ -387,7 +413,7 @@ export default function CausesScreen() {
           </View>
         )}
 
-        <ClubSection />
+        <ClubSection isMember={isMember} refetch={refetchIsMember} />
       </ScrollView>
       <DonationErrorModal newState={params?.newState} />
     </>

--- a/src/screens/promoters/PixInstructionsScreen/index.tsx
+++ b/src/screens/promoters/PixInstructionsScreen/index.tsx
@@ -26,6 +26,7 @@ import usePayable from "hooks/usePayable";
 import Icon from "components/atomics/Icon";
 import TrustSeal from "components/moleculars/TrustSeal";
 import PaymentPlaceholder from "components/moleculars/PaymentPlaceholder";
+import { useNavigation } from "hooks/useNavigation";
 import S from "./styles";
 
 function PixInstructionsScreen(): JSX.Element {
@@ -35,8 +36,7 @@ function PixInstructionsScreen(): JSX.Element {
     keyPrefix: "promoters.pixInstructionsScreen",
   });
 
-  const { verifyPayment, pixInstructions, handleBackButtonClick } =
-    usePixPaymentInformation();
+  const { verifyPayment, pixInstructions } = usePixPaymentInformation();
 
   const copyToClipboard = () => {
     Clipboard.setString(
@@ -48,6 +48,12 @@ function PixInstructionsScreen(): JSX.Element {
   const { target, targetId } = useCheckoutContext();
 
   const payable = usePayable(target, targetId);
+
+  const { navigateTo } = useNavigation();
+
+  const handleBackButtonClick = () => {
+    navigateTo("CausesScreen");
+  };
 
   useEffect(() => {
     if (pixInstructions && pixInstructions.clientSecret) {


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Refresing isMember, tickets and firstAccessToIntegration when scroll down on causes page 

## Does this pull request close any open issues?

- Put here the issue that must be closed with this PR
- eg: closes [#PROD3-501]()

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

- Create a subscription by pix and verify if banner disappear when refresh 
