### PR TITLE
feat: native animated toast

### DIFF
--- a/src/components/atomics/animations/NewTicketAnimation/index.tsx
+++ b/src/components/atomics/animations/NewTicketAnimation/index.tsx
@@ -1,4 +1,5 @@
-import Animated, { Keyframe } from "react-native-reanimated";
+import { useEffect, useRef } from "react";
+import { Animated } from "react-native";
 import Icon from "components/atomics/Icon";
 import { theme } from "@ribon.io/shared";
 import * as S from "./styles";
@@ -8,27 +9,47 @@ export type Props = {
 };
 
 export default function NewTicketAnimation({ count = 1 }: Props): JSX.Element {
-  const keyframe = new Keyframe({
-    0: {
-      opacity: 0,
-      transform: [{ translateY: 0 }],
-    },
-    20: {
-      opacity: 1,
-      transform: [{ translateY: -20 }],
-    },
-    80: {
-      opacity: 1,
-      transform: [{ translateY: -30 }],
-    },
-    100: {
-      opacity: 0,
-      transform: [{ translateY: -40 }],
-    },
-  });
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.sequence([
+      Animated.parallel([
+        Animated.timing(fadeAnim, {
+          toValue: 1,
+          duration: 160,
+          useNativeDriver: true,
+        }),
+        Animated.timing(translateY, {
+          toValue: -20,
+          duration: 160,
+          useNativeDriver: true,
+        }),
+      ]),
+      Animated.timing(translateY, {
+        toValue: -30,
+        duration: 480,
+        useNativeDriver: true,
+      }),
+      Animated.parallel([
+        Animated.timing(fadeAnim, {
+          toValue: 0,
+          duration: 160,
+          useNativeDriver: true,
+        }),
+        Animated.timing(translateY, {
+          toValue: -40,
+          duration: 160,
+          useNativeDriver: true,
+        }),
+      ]),
+    ]).start();
+  }, []);
 
   return (
-    <Animated.View entering={keyframe.duration(800)}>
+    <Animated.View
+      style={{ opacity: fadeAnim, transform: [{ translateY }] }}
+    >
       <S.Container>
         <S.Count>+{count}</S.Count>
         <Icon

--- a/src/components/atomics/animations/NewTicketAnimation/index.tsx
+++ b/src/components/atomics/animations/NewTicketAnimation/index.tsx
@@ -16,6 +16,18 @@ export default function NewTicketAnimation({ count = 1 }: Props): JSX.Element {
     Animated.sequence([
       Animated.parallel([
         Animated.timing(fadeAnim, {
+          toValue: 0,
+          duration: 0,
+          useNativeDriver: true,
+        }),
+        Animated.timing(translateY, {
+          toValue: 0,
+          duration: 0,
+          useNativeDriver: true,
+        }),
+      ]),
+      Animated.parallel([
+        Animated.timing(fadeAnim, {
           toValue: 1,
           duration: 160,
           useNativeDriver: true,
@@ -47,9 +59,7 @@ export default function NewTicketAnimation({ count = 1 }: Props): JSX.Element {
   }, []);
 
   return (
-    <Animated.View
-      style={{ opacity: fadeAnim, transform: [{ translateY }] }}
-    >
+    <Animated.View style={{ opacity: fadeAnim, transform: [{ translateY }] }}>
       <S.Container>
         <S.Count>+{count}</S.Count>
         <Icon


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
Converts the new ticket animation to use the Animated native module, instead of react-native-reanimated.

NOTE: The demonstration below refers only to the TOAST animation. The button still using reanimated for now.

https://github.com/RibonDAO/app/assets/24739860/a7931e92-0e4f-494b-81c0-c598ddd4c66a



## Did you use styled-components?

- [ ] Yes
- [x] No

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests
