### PR TITLE
fix: use react native share instead of expo sharing

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "expo-linear-gradient": "~12.7.2",
     "expo-linking": "~6.2.2",
     "expo-localization": "~14.8.4",
-    "expo-sharing": "~11.10.0",
     "expo-splash-screen": "~0.26.4",
     "expo-status-bar": "~1.11.1",
     "expo-system-ui": "~2.9.4",

--- a/src/components/moleculars/CardReferral/index.tsx
+++ b/src/components/moleculars/CardReferral/index.tsx
@@ -2,12 +2,11 @@ import { useTranslation } from "react-i18next";
 import { logEvent } from "services/analytics";
 import { Integration } from "@ribon.io/shared/types/entities";
 import { useEffect, useState } from "react";
-import { View } from "react-native";
+import { View, Share } from "react-native";
 import useUserIntegration from "hooks/userHooks/useUserIntegration";
 import { useCurrentUser } from "contexts/currentUserContext";
 import { useUserProfile } from "@ribon.io/shared";
 import { useLanguage } from "contexts/languageContext";
-import * as Sharing from "expo-sharing";
 import Star from "./assets/Shape";
 import Letter from "./assets/Letter";
 import * as S from "./styles";
@@ -62,7 +61,9 @@ function CardReferral(): JSX.Element {
 
   const copyTextToClipboard = (data?: Integration) => {
     const text = finalLink(data);
-    Sharing.shareAsync(text);
+    Share.share({
+      message: text,
+    });
   };
 
   const handleClick = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7724,11 +7724,6 @@ expo-pwa@0.0.127:
     commander "2.20.0"
     update-check "1.5.3"
 
-expo-sharing@~11.10.0:
-  version "11.10.0"
-  resolved "https://registry.yarnpkg.com/expo-sharing/-/expo-sharing-11.10.0.tgz#0e85197ee4d2634b00fe201e571fbdc64cf83eef"
-  integrity sha512-/64RyyKlZ25WfnMXa87HbPXhIIqWwNbIku/RaIYAq4SE0XTRC+KTH3v0XFkfDa+SCG/jKsAr1pJ3vQvsNo1sCQ==
-
 expo-splash-screen@~0.26.4:
   version "0.26.4"
   resolved "https://registry.yarnpkg.com/expo-splash-screen/-/expo-splash-screen-0.26.4.tgz#bc1fb226c6eae03ee351a3ebe5521a37f868cbc7"


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
Fix sharing context menu on android. Doing a synchronous approach by using react native share instead of expo sharing

## Did you use styled-components?

- [ ] Yes
- [x] No

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests
