### PR TITLE
Fix: reward text problem

### DIFF
--- a/src/screens/coupons/GiveTicketByCouponScreen/index.tsx
+++ b/src/screens/coupons/GiveTicketByCouponScreen/index.tsx
@@ -22,7 +22,11 @@ export default function GiveTicketByCouponScreen() {
   interface ICoupon {
     id: string;
     numberOfTickets: number;
-    rewardText?: string;
+    couponMessage: {
+      id: string;
+      rewardText?: string;
+      couponId: string;
+    };
   }
 
   const { couponId, setCouponId } = useCouponContext();
@@ -94,7 +98,7 @@ export default function GiveTicketByCouponScreen() {
               ? t("titlePlural", { numberOfTickets })
               : t("title")}
           </Text>
-          <Text style={S.subtitle}>{coupon?.rewardText}</Text>
+          <Text style={S.subtitle}>{coupon?.couponMessage?.rewardText}</Text>
         </View>
 
         <Button


### PR DESCRIPTION
# Description

- The reward text was previously nor rendering correctly because of the changes at the coupon and CouponMessage tables. This should fix it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

- Open the deeplink with a valid coupon id `https://donation.app.link/fTSdbk1OiJb?coupon_id=bc1e450a-ff8c-4255-bd1b-8370752a70f0`
