### PR TITLE
fix: set utm param to people who doesnt came from deeplink

### DIFF
--- a/src/services/deepLink/index.ts
+++ b/src/services/deepLink/index.ts
@@ -26,9 +26,10 @@ export async function initializeDeeplink(
         (latestParams.integration_id as string) || RIBON_INTEGRATION_ID;
 
       const externalId = (latestParams.external_id as string) || "";
-      const utmSource = (latestParams.utm_source as string) || "";
-      const utmMedium = (latestParams.utm_medium as string) || "";
-      const utmCampaign = (latestParams.utm_campaign as string) || "";
+      const utmSource = (latestParams.utm_source as string) || "organic_unset";
+      const utmMedium = (latestParams.utm_medium as string) || "organic_unset";
+      const utmCampaign =
+        (latestParams.utm_campaign as string) || "organic_unset";
 
       const magicLinkToken = (latestParams.authToken as string) || "";
       const accountId = (latestParams.id as string) || "";


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- Set utm to organic_unset, when user doesnt came from a deeplink. 


## Did you use styled-components?

- [ ] Yes
- [x] No

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests
