### PR TITLE
feat: move the entire otp responsabilities to the send otp screen

### DIFF
--- a/src/config/navigation/index.tsx
+++ b/src/config/navigation/index.tsx
@@ -61,7 +61,6 @@ import SignInScreen from "screens/auth/SignInScreen";
 import InsertEmailScreen from "screens/auth/InsertEmailScreen";
 import InsertOtpCodeScreen from "screens/auth/InsertOtpCodeScreen";
 import InsertEmailAccountScreen from "screens/donations/auth/InsertEmailAccountScreen";
-import { useAuthentication } from "contexts/authenticationContext";
 import SelectTicketsScreen from "screens/donations/SelectTicketsScreen";
 import ValidateAccountScreen from "screens/auth/ValidateAccountScreen";
 import ClubContributionDoneScreen from "screens/promoters/ClubContributionDoneScreen";
@@ -81,7 +80,6 @@ import PaymentFailedNotificationProvider from "contexts/paymentFailedNotificatio
 import ClubSubscriptionProvider from "contexts/clubSubscriptionContext";
 import TagsProvider from "contexts/tagsContext";
 import { initializeDeeplink } from "../../services/deepLink";
-import S from "./styles";
 import LinkingConfiguration from "./LinkingConfiguration";
 import ImpactIconOn from "./assets/ImpactIconOn";
 import ImpactIconOff from "./assets/ImpactIconOff";
@@ -89,6 +87,7 @@ import CausesIconOff from "./assets/CausesIconOff";
 import CausesIconOn from "./assets/CausesIconOn";
 import EarnTicketsIconOn from "./assets/EarnTicketsIconOn";
 import EarnTicketsIconOff from "./assets/EarnTicketsIconOff";
+import S from "./styles";
 
 const { primary } = theme.colors.brand;
 const { neutral } = theme.colors;
@@ -210,7 +209,6 @@ function PrivateNavigator() {
   const { navigateTo } = useNavigation();
   const { setCurrentIntegrationId, setExternalId } = useIntegrationContext();
   const { setUtm } = useUtmContext();
-  const { setMagicLinkToken, setAccountId } = useAuthentication();
   const { setCouponId } = useCouponContext();
   useEffect(() => {
     initializeDeeplink(
@@ -218,8 +216,6 @@ function PrivateNavigator() {
       setCurrentIntegrationId,
       setExternalId,
       setUtm,
-      setMagicLinkToken,
-      setAccountId,
       setCouponId,
     );
   }, []);
@@ -242,7 +238,6 @@ function RootNavigator() {
   const { navigateTo } = useNavigation();
   const { setCurrentIntegrationId, setExternalId } = useIntegrationContext();
   const { setUtm } = useUtmContext();
-  const { setMagicLinkToken, setAccountId } = useAuthentication();
   const { setCouponId } = useCouponContext();
   useEffect(() => {
     initializeDeeplink(
@@ -250,8 +245,6 @@ function RootNavigator() {
       setCurrentIntegrationId,
       setExternalId,
       setUtm,
-      setMagicLinkToken,
-      setAccountId,
       setCouponId,
     );
   }, []);

--- a/src/contexts/authenticationContext/index.tsx
+++ b/src/contexts/authenticationContext/index.tsx
@@ -16,11 +16,6 @@ import { logError } from "services/crashReport";
 // TODO: Use the shared methods when R4B structure is done
 import otpAuthenticationApi from "services/user/userAuthenticationApi";
 
-type authTokenProps = {
-  onSuccess?: () => void;
-  onError?: () => void;
-};
-
 type otpAuthProps = {
   code: string;
   onSuccess?: () => void;
@@ -35,17 +30,11 @@ type authenticationEmailProps = {
 };
 export interface IAuthenticationContext {
   accessToken: string | null;
-  magicLinkToken: string | null;
   accountId: string | null;
   logout: () => void;
   signInWithGoogle: (response: any) => void;
-  signInByMagicLink: (signInByMagicLinkProps: authTokenProps) => void;
-  sendAuthenticationEmail: (
-    sendAuthenticationEmailProps: authenticationEmailProps,
-  ) => void;
   signInWithApple: (response: any) => void;
   isAuthenticated: () => boolean;
-  setMagicLinkToken: (token: string) => void;
   setAccountId: (id: string) => void;
   sendOtpEmail: (
     sendOtpEmailProps: authenticationEmailProps,
@@ -63,7 +52,6 @@ export const AuthenticationContext = createContext<IAuthenticationContext>(
 
 function AuthenticationProvider({ children }: Props) {
   const [accessToken, setAccessToken] = useState<string | null>("");
-  const [magicLinkToken, setMagicLinkToken] = useState("");
   const [accountId, setAccountId] = useState("");
   const { setCurrentUser } = useCurrentUser();
   const emailDoesNotMatchMessage = "Email does not match";
@@ -113,43 +101,6 @@ function AuthenticationProvider({ children }: Props) {
       }
       throw new Error("google auth error");
     }
-  }
-
-  async function signInByMagicLink({ onSuccess, onError }: authTokenProps) {
-    try {
-      const response = await userAuthenticationApi.postAuthorizeFromAuthToken(
-        magicLinkToken,
-        accountId,
-      );
-
-      signIn(response);
-
-      if (onSuccess) onSuccess();
-    } catch (error: any) {
-      logError(error);
-      if (onError) onError();
-    }
-  }
-
-  async function sendAuthenticationEmail({
-    email,
-    id,
-    onSuccess,
-    onError,
-  }: authenticationEmailProps) {
-    try {
-      const response = await userAuthenticationApi.postSendAuthenticationEmail(
-        email,
-        id,
-      );
-      if (onSuccess) onSuccess();
-      setCurrentUser(response.data.user);
-      return response.data.user.email;
-    } catch (error: any) {
-      logError(error);
-      if (onError) onError();
-    }
-    return "";
   }
 
   async function sendOtpEmail({
@@ -216,18 +167,14 @@ function AuthenticationProvider({ children }: Props) {
       logout,
       accessToken,
       signInWithGoogle,
-      signInByMagicLink,
-      sendAuthenticationEmail,
       signInWithApple,
       isAuthenticated,
       accountId,
       setAccountId,
-      magicLinkToken,
-      setMagicLinkToken,
       sendOtpEmail,
       signInByOtp,
     }),
-    [accessToken, magicLinkToken, accountId],
+    [accessToken, accountId],
   );
 
   return (

--- a/src/screens/auth/InsertEmailScreen/index.tsx
+++ b/src/screens/auth/InsertEmailScreen/index.tsx
@@ -12,12 +12,10 @@ import PrivacyPolicyLayout from "components/moleculars/layouts/PrivacyPolicyLayo
 import { useNavigation } from "hooks/useNavigation";
 import InputText from "components/atomics/inputs/InputText";
 import { isValidEmail } from "lib/validators";
-import { useCallback, useEffect, useState } from "react";
-import { useAuthentication } from "contexts/authenticationContext";
+import { useEffect, useState } from "react";
 import { logEvent } from "services/analytics";
 import { theme } from "@ribon.io/shared";
 import Button from "components/atomics/buttons/Button";
-import { useFocusEffect } from "@react-navigation/native";
 import UserAvatarIcon from "../assets/UserAvatarIcon";
 import S from "./styles";
 
@@ -27,11 +25,7 @@ function InsertEmailScreen() {
   });
 
   const [email, setEmail] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [emailSent, setEmailSent] = useState(false);
   const { navigateTo } = useNavigation();
-
-  const { sendOtpEmail } = useAuthentication();
 
   useEffect(() => {
     logEvent("P28_view", {
@@ -39,22 +33,7 @@ function InsertEmailScreen() {
     });
   }, []);
 
-  useFocusEffect(
-    useCallback(() => {
-      setLoading(false);
-      setEmailSent(false);
-    }, []),
-  );
-
-  const handleButtonPress = async () => {
-    if (emailSent) return;
-
-    setLoading(true);
-    await sendOtpEmail({ email });
-    logEvent("authEmailFormBtn_click", {
-      from: "sign_in",
-    });
-    setEmailSent(true);
+  const handleButtonPress = () => {
     navigateTo("InsertOtpCodeScreen", { email });
   };
 
@@ -89,18 +68,16 @@ function InsertEmailScreen() {
               autoFocus
               containerStyle={S.inputContainer}
               style={S.input}
-              disabled={loading}
             />
 
             <Button
               text={t("confirmText")}
               onPress={handleButtonPress}
-              disabled={!isValidEmail(email) || loading}
-              customStyles={loading ? S.buttonDisabled : S.button}
+              disabled={!isValidEmail(email)}
+              customStyles={S.button}
               customTextStyles={{
                 color: theme.colors.neutral10,
               }}
-              loading={loading}
             />
             <PrivacyPolicyLayout />
           </View>

--- a/src/screens/auth/InsertOtpCodeScreen/index.tsx
+++ b/src/screens/auth/InsertOtpCodeScreen/index.tsx
@@ -58,17 +58,20 @@ function InsertOtpCodeScreen() {
   const { navigateTo } = useNavigation();
   const { signInByOtp, sendOtpEmail } = useAuthentication();
 
-  const sendEmail = useCallback(() => {
-    sendOtpEmail({ email });
-  }, [email]);
-
   useEffect(() => {
-    if (!email || !isValidEmail(email)) {
+    if (!isValidEmail(email)) {
       navigateTo("InsertEmailScreen");
       return;
     }
 
     logEvent("P36_view");
+  }, []);
+
+  const sendEmail = useCallback(() => {
+    if (isValidEmail(email)) sendOtpEmail({ email });
+  }, [email]);
+
+  useEffect(() => {
     sendEmail();
   }, [email]);
 

--- a/src/screens/auth/InsertOtpCodeScreen/index.tsx
+++ b/src/screens/auth/InsertOtpCodeScreen/index.tsx
@@ -25,6 +25,7 @@ import { useRouteParams } from "hooks/useRouteParams";
 import Icon from "components/atomics/Icon";
 import { isValidEmail, isValidOTP } from "lib/validators";
 import { countdown } from "lib/timeoutHelpers";
+import { showToast } from "lib/Toast";
 import LockIcon from "../assets/LockIcon";
 import S from "./styles";
 
@@ -78,6 +79,11 @@ function InsertOtpCodeScreen() {
     signInByOtp({
       code: currentOtpCode,
       onSuccess: () => {
+        showToast({
+          type: "success",
+          message: t("successToastMessage"),
+          position: "bottom",
+        });
         navigateTo("TabNavigator", { screen: "CausesScreen" });
       },
       onError: () => {

--- a/src/screens/auth/ValidateAccountScreen/index.tsx
+++ b/src/screens/auth/ValidateAccountScreen/index.tsx
@@ -11,7 +11,7 @@ function ValidateAccountScreen() {
 
   const { navigateTo } = useNavigation();
   const { currentUser } = useCurrentUser();
-  const { isAuthenticated, sendOtpEmail, accountId } = useAuthentication();
+  const { isAuthenticated, accountId } = useAuthentication();
 
   const handleAuthenticatedUser = () => {
     navigateTo("TabNavigator", { screen: "CausesScreen" });
@@ -22,7 +22,6 @@ function ValidateAccountScreen() {
   };
 
   const handleUserWithoutAccountId = () => {
-    sendOtpEmail({ email: currentUser?.email });
     navigateTo("InsertOtpCodeScreen", { email: currentUser?.email });
   };
 

--- a/src/screens/coupons/auth/InsertEmailCouponScreen/index.tsx
+++ b/src/screens/coupons/auth/InsertEmailCouponScreen/index.tsx
@@ -13,7 +13,6 @@ import { useNavigation } from "hooks/useNavigation";
 import InputText from "components/atomics/inputs/InputText";
 import { isValidEmail } from "lib/validators";
 import { useEffect, useState } from "react";
-import { useAuthentication } from "contexts/authenticationContext";
 import { logEvent } from "services/analytics";
 import { theme } from "@ribon.io/shared";
 import Button from "components/atomics/buttons/Button";
@@ -28,8 +27,6 @@ function InsertEmailCouponScreen() {
   const [email, setEmail] = useState("");
   const { navigateTo } = useNavigation();
 
-  const { sendOtpEmail } = useAuthentication();
-
   useEffect(() => {
     logEvent("P28_view", {
       from: "coupon_flow",
@@ -37,7 +34,6 @@ function InsertEmailCouponScreen() {
   }, []);
 
   const handleButtonPress = async () => {
-    await sendOtpEmail({ email });
     logEvent("authEmailFormBtn_click", {
       from: "coupon_flow",
     });

--- a/src/screens/donations/auth/InsertEmailAccountScreen/index.tsx
+++ b/src/screens/donations/auth/InsertEmailAccountScreen/index.tsx
@@ -15,7 +15,6 @@ import InputText from "components/atomics/inputs/InputText";
 import Image from "components/atomics/Image";
 import useFormattedImpactText from "hooks/useFormattedImpactText";
 import PrivacyPolicyLayout from "components/moleculars/layouts/PrivacyPolicyLayout";
-import { useAuthentication } from "contexts/authenticationContext";
 import { logEvent } from "services/analytics";
 import { useRouteParams } from "hooks/useRouteParams";
 import { theme } from "@ribon.io/shared";
@@ -34,7 +33,6 @@ function InsertEmailAccountScreen() {
   });
   const [email, setEmail] = useState("");
 
-  const { sendOtpEmail } = useAuthentication();
   const { handleCollectAndDonate } = useDonationFlow();
   const { formattedImpactText } = useFormattedImpactText();
   const { navigateTo } = useNavigation();
@@ -78,7 +76,6 @@ function InsertEmailAccountScreen() {
   }, [donationSucceeded]);
 
   async function donateCallback() {
-    await sendOtpEmail({ email });
     await handleCollectAndDonate({
       nonProfit,
       email,

--- a/src/services/deepLink/index.ts
+++ b/src/services/deepLink/index.ts
@@ -9,8 +9,6 @@ export async function initializeDeeplink(
   setCurrentIntegrationId: (integrationId: string | number) => void,
   setExternalId: (externalId: string) => void,
   setUtm: (utmSource: string, utmMedium: string, utmCampaign: string) => void,
-  setMagicLinkToken: (magicLinkToken: string) => void,
-  setAccountId: (accountId: string) => void,
   setCouponId: (couponId: string) => void,
 ) {
   branch.subscribe({
@@ -31,18 +29,11 @@ export async function initializeDeeplink(
       const utmCampaign =
         (latestParams.utm_campaign as string) || "organic_unset";
 
-      const magicLinkToken = (latestParams.authToken as string) || "";
-      const accountId = (latestParams.id as string) || "";
       const couponId = (latestParams.coupon_id as string) || "";
 
       setCurrentIntegrationId(integrationId);
       setExternalId(externalId);
-
       setUtm(utmSource, utmMedium, utmCampaign);
-
-      setMagicLinkToken(magicLinkToken);
-      setAccountId(accountId);
-
       setCouponId(couponId);
 
       try {

--- a/src/utils/translations/en.json
+++ b/src/utils/translations/en.json
@@ -690,7 +690,8 @@
       "subtitle": "Enter the 6-digit verification code sent to {{email}}",
       "confirmText": "Continue",
       "resendText": "Resend code",
-      "incorrectCode": "Incorrect code. Please try again."
+      "incorrectCode": "Incorrect code. Please try again.",
+      "successToastMessage": "Account validated"
     },
     "insertEmailCouponScreen": {
       "title": "Sign in with an e-mail",

--- a/src/utils/translations/pt.json
+++ b/src/utils/translations/pt.json
@@ -682,7 +682,8 @@
       "subtitle": "Por favor, insira o código de 6 dígitos enviado para {{email}}",
       "confirmText": "Continuar",
       "resendText": "Reenviar código",
-      "incorrectCode": "Código incorreto. Tente novamente, por favor."
+      "incorrectCode": "Código incorreto. Tente novamente, por favor.",
+      "successToastMessage": "Conta verificada"
     },
     "insertEmailCouponScreen": {
       "title": "Entre com um e-mail",


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
 - Move all email sending responsability to the Insert OTP page itself. We've added a email based callback as well, to prevent code sending and regeneration multiple times (death to react lifecycle)
 - Verified account toast to improve experience


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

